### PR TITLE
Option to disable PR reviews being posted

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,3 +16,4 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: 'bug, enhancement'
           pull-request-number: '${{ github.event.pull_request.number }}'
+          disable-reviews: false

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Fortunately, Github recently added a new trigger event `pull_request_target` whi
 
 **Optional** The pull request number, available in the github context: `${{ github.event.pull_request.number }}`. This number is automatically extracted from the environmental variables when the action triggers on `pull_request`. However, when the trigger used is `pull_request_target`, then this input must be used.
 
+### `disable-reviews`
+
+**Optional** Set to `true` to have the action skip the approval posting step and return a failure exit status code instead. 
+
 ## Example usage
 
 ### If you want to allow PRs from forks

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   pull-request-number:
     description: 'The Pull Request number'
     required: false
+  disable-reviews:
+    description: 'Should the action post reviews on PRs'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -21,3 +24,4 @@ runs:
     - ${{ inputs.github-token }}
     - ${{ inputs.valid-labels }}
     - ${{ inputs.pull-request-number }}
+    - ${{ inputs.disable-reviews }}

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -145,6 +145,7 @@ if pr_valid_labels:
     print(f'Success! This pull request contains the following valid labels: {pr_valid_labels}')
 
     if pr_reviews_disabled:
+        print('Exiting without an error code')
         exit(0)
 
     # If the last review done was approved, then don't approved it again
@@ -154,9 +155,10 @@ if pr_valid_labels:
         pr.create_review(event = 'APPROVE')
 else:
     # If there were not valid labels, then create a pull request review, requesting changes
-    print(f'Error! This pull request does not contain any of the valid labels: {valid_labels}')
+    print(f'Error! This pull request does not contain any of the valid labels: {valid_labels}', file=sys.stderr)
 
     if pr_reviews_disabled:
+        print('Exiting with an error code')
         exit(1)
 
     # If the last review done requested changes, then don't request changes again.

--- a/verify_pr_lables.py
+++ b/verify_pr_lables.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import re
+import distutils.util
 from github import Github
 
 def get_env_var(env_var_name, echo_value=False):
@@ -34,8 +35,8 @@ def get_env_var(env_var_name, echo_value=False):
     return value
 
 # Check if the number of input arguments is correct
-if len(sys.argv) != 4:
-    raise ValueError('Invalid number of arguments!')
+if len(sys.argv) != 5:
+    raise ValueError("Invalid number of arguments!")
 
 # Get the GitHub token
 token=sys.argv[1]
@@ -46,6 +47,13 @@ print(f'Valid labels are: {valid_labels}')
 
 # Get the PR number
 pr_number_str=sys.argv[3]
+
+# Are reviews disabled?
+try:
+    pr_reviews_disabled = bool(distutils.util.strtobool(sys.argv[4]))
+except ValueError:
+    pr_reviews_disabled = False
+print(f"PR reviews are: {'disabled' if pr_reviews_disabled else 'enabled'}")
 
 # Get needed values from the environmental variables
 repo_name=get_env_var('GITHUB_REPOSITORY')
@@ -136,6 +144,9 @@ if pr_valid_labels:
     # If there were valid labels, create a pull request review, approving it
     print(f'Success! This pull request contains the following valid labels: {pr_valid_labels}')
 
+    if pr_reviews_disabled:
+        exit(0)
+
     # If the last review done was approved, then don't approved it again
     if was_approved:
         print('The last review was already approved')
@@ -144,6 +155,9 @@ if pr_valid_labels:
 else:
     # If there were not valid labels, then create a pull request review, requesting changes
     print(f'Error! This pull request does not contain any of the valid labels: {valid_labels}')
+
+    if pr_reviews_disabled:
+        exit(1)
 
     # If the last review done requested changes, then don't request changes again.
     # 'was_approved' can be 'None', so here we need to explicitly compare against 'False'.


### PR DESCRIPTION
Adds an option `disable-reviews` that prevents PR reviews from being posted and instead returns an error code.